### PR TITLE
Beautify the UI a tiny little bit

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "build": {
     "appId": "eve-settings-manager",
-    "productName": "EVE Settings Manager v1.0.1",
+    "productName": "EVE Settings Manager v1.1.0",
     "mac": {
       "icon": "src/assets/icon.png"
     },
@@ -37,7 +37,7 @@
       "icon": "src/assets/icon.png"
     },
     "portable": {
-      "artifactName": "EVE Settings Manager v1.0.1.exe"
+      "artifactName": "EVE Settings Manager v1.1.0.exe"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eve-settings-manager",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "EVE Online Settings Manager",
   "main": "src/main.js",
   "repository": "github.com/mintnick/eve-settings-manager",

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -104,6 +104,7 @@ tr {
   position: absolute;
   width: 100%;
   top: 175px;
+  padding-left: 1.5rem;
 }
 
 #table-section select > option{

--- a/src/js/change-language.js
+++ b/src/js/change-language.js
@@ -47,13 +47,23 @@ function changeLanguage(lang) {
   playerCountTitle.text(titles.players)
 
   // buttons
+  const setTooltip = (selector, tooltip) => {
+    const button = $(selector)
+    button.attr('data-tooltip', tooltip)
+    button.removeClass('tooltip-btn')
+    if (tooltip) {
+      button.addClass('tooltip-btn')
+    }
+  }
   const buttons = locale.buttons;
   selectFolderBtn.text(buttons.selectFolder)
+  setTooltip('#select-folder-btn', buttons.selectFolderTooltip)
   openFolderBtn.text(buttons.openFolder)
+  setTooltip('#open-folder-btn', buttons.openFolderTooltip)
   backupBtn.text(buttons.backup)
-  $('#backup-btn').attr('data-tooltip', buttons.backupTooltip)
+  setTooltip('#backup-btn', buttons.backupTooltip)
   clearCacheBtn.text(buttons.clearCache)
-  $('#clear-cache-btn').attr('data-tooltip', buttons.clearCacheTooltip)
+  setTooltip('#clear-cache-btn', buttons.clearCacheTooltip)
   overwriteCharBtn.text(buttons.overwriteChar)
   overwriteSelectedCharBtn.text(buttons.overwriteSelectedChar)
   overwriteAccountBtn.text(buttons.overwriteAccount)

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -61,11 +61,6 @@ async function initSelects() {
   }
   // serverSelect.val(server)
   await changeServer(server)
-
-  // set file select size
-  const selects = $('#table-section select')
-  const os = process.platform
-  if (os == 'darwin') selects.attr('size', 20)
 }
 
 function bindEvents() {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -22,7 +22,9 @@
   },
   "buttons": {
     "selectFolder": "Select Folder",
+    "selectFolderTooltip": "Allows selecting a custom profile directory",
     "openFolder": "Open Folder",
+    "openFolderTooltip": "Opens the folder for the selected profile in the system file manager",
     "backup": "Backup",
     "backupTooltip": "Backup setting files",
     "clearCache": "Clear Cache",

--- a/src/locales/zh-CHT.json
+++ b/src/locales/zh-CHT.json
@@ -22,7 +22,9 @@
   },
   "buttons": {
     "selectFolder": "選擇資料夾",
+    "selectFolderTooltip": "選擇一個設定資料夾",
     "openFolder": "打開資料夾",
+    "openFolderTooltip": "在資源管理器中打開當前資料夾",
     "backup": "備份",
     "backupTooltip": "備份本地文件",
     "clearCache": "清除設定",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -22,7 +22,9 @@
   },
   "buttons": {
     "selectFolder": "选择文件夹",
+    "selectFolderTooltip": "手动选择设置文件夹",
     "openFolder": "打开文件夹",
+    "openFolderTooltip": "在资源管理器中打开设置文件夹",
     "backup": "备份",
     "backupTooltip": "备份设置文件",
     "clearCache": "清空缓存",

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -39,7 +39,7 @@
         </div>
       </div>
       <div id="folder-section" class="border-bottom">
-        <div id="folder-selector border-bottom" class="px-2">
+        <div id="folder-selector border-bottom" class="px-4">
           <select id="folder-select" class="form-select" aria-label="Default select example">
           </select>
         </div>

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -44,11 +44,11 @@
           </select>
         </div>
         <div id="folder-buttons" class="d-flex justify-content-evenly mt-2">
-          <button id="select-folder-btn" type="button" class="btn btn-outline-dark">
+          <button id="select-folder-btn" type="button" class="tooltip-btn btn btn-outline-dark" data-tooltip="tooltip">
             <img src="../assets/check2-square.svg"/>
             <span id="select-folder-btn-text">select folder</span>
           </button>
-          <button id="open-folder-btn" type="button" class="btn btn-outline-dark">
+          <button id="open-folder-btn" type="button" class="tooltip-btn btn btn-outline-dark" data-tooltip="tooltip">
             <img src="../assets/folder2-open.svg"/>
             <span id="open-folder-btn-text">open folder</span>
           </button>


### PR DESCRIPTION
This pull requests adds three small changes:

* It visually unifies the padding on the left and the right side of the folder select box and the character/account select boxes.
* It adds tooltips for the “select folder” and “open folder” buttons.
* It makes the character/account select lists smaller on macOS, partially reverting 35234e68c090c3cc304fae44e46df77611e7c1c2. On my system the increased size caused the lists and the buttons below them to overlap.