### PR TITLE
Use new launcher profiles

### DIFF
--- a/src/js/backup.js
+++ b/src/js/backup.js
@@ -5,12 +5,14 @@ const { getLocale } = require('./change-language')
 const { readdir, mkdir, copyFile } = require('node:fs/promises')
 const { join } = require('path')
 const { ipcRenderer } = require('electron')
+const { getSelectedProfile } = require('./eve-folder')
 
 async function backupFiles() {
   let folderPath = $('#folder-select').val()
   if (!folderPath) return
 
-  folderPath = join(folderPath, 'settings_Default')
+  const profile = getSelectedProfile()
+  folderPath = join(folderPath, profile)
   const files =
   (await readdir(folderPath, { withFileTypes: true }))
   .filter(dirent => dirent.isFile())

--- a/src/js/change-language.js
+++ b/src/js/change-language.js
@@ -2,6 +2,7 @@
 
 const $ = require('jquery')
 const AppConfig = require('../configuration')
+const { setSelectOptions } = require('./select-options')
 
 function changeLanguage(lang) {
   AppConfig.saveSettings('language', lang);
@@ -28,14 +29,7 @@ function changeLanguage(lang) {
   // server select
   const servers = locale.servers;
   const server = AppConfig.readSettings('server') ?? 'tranquility'
-  serverSelect.find('option').remove();
-  for (const [key, value] of Object.entries(servers)) {
-    serverSelect.append($('<option>', {
-      value: key,
-      text: value,
-    }))
-  }
-  serverSelect.find('option[value="' + server + '"]').prop("selected", true)
+  setSelectOptions(serverSelect, Object.entries(servers).map(([key, value]) => ({ value: key, text: value, selected: key === server })))
   serverTitle.text(serverSelect.find(":selected").text())
   
   // titles

--- a/src/js/eve-folder.js
+++ b/src/js/eve-folder.js
@@ -42,7 +42,7 @@ const urls = {
     "thunderdome": ""
   }
 }
-const settingFolderName = 'settings_Default'
+const defaultSettingFolderName = 'settings_Default'
 
 // read default setting folders, render in folder select
 async function readDefaultFolders() {
@@ -85,9 +85,13 @@ async function setSelectedFolder(folderPath) {
   readSettingFiles()
 }
 
+function getSelectedProfile() {
+  return $('#profile-select').val() ?? defaultSettingFolderName
+}
+
 // open selected folder in OS
 function openFolder() {
-  const folderPath = join($('#folder-select').val(), settingFolderName)
+  const folderPath = join($('#folder-select').val(), getSelectedProfile())
   // shell.showItemInFolder(folderPath)
   shell.openPath(folderPath)
 }
@@ -106,6 +110,8 @@ async function readSettingFiles() {
     setSelectOptions(selects, [])
     return
   }
+
+  const settingFolderName = getSelectedProfile()
   const folderPath = join(selectedFolder, settingFolderName)
   if (!existsSync(folderPath)) {
     setSelectOptions(selects, [])
@@ -222,6 +228,7 @@ async function overwrite(args) {
 }
 
 module.exports = {
+  getSelectedProfile,
   readDefaultFolders,
   setSelectedFolder,
   openFolder,

--- a/src/js/eve-folder.js
+++ b/src/js/eve-folder.js
@@ -44,6 +44,35 @@ const urls = {
 }
 const defaultSettingFolderName = 'settings_Default'
 
+/**
+ * Finds all profiles from the current server’s settings directory and
+ * populates the profile selection table.
+ *
+ * @returns {Promise<void>}
+ */
+async function findProfiles() {
+  await readDefaultFolders()
+
+  // clear table
+  const profileSelect = $('#profile-select')
+  setSelectLoading(profileSelect)
+
+  const selectedFolder = $('#folder-select').val()
+  if (!selectedFolder) {
+    setSelectOptions(profileSelect, [])
+    return;
+  }
+
+  const profileDirectories = (await readdir(selectedFolder, {withFileTypes: true}))
+      .filter(entry => entry.isDirectory())
+      .filter(entry => entry.name.startsWith('settings_'))
+      .map(entry => entry.name)
+
+  // add profiles to profile table
+  const profileDirectoryToOption = profileDirectory => ({ value: profileDirectory, text: profileDirectory.replace(/^settings_/, '').replaceAll(/_/g, ' ') })
+  setSelectOptions(profileSelect, profileDirectories.map(profileDirectoryToOption))
+}
+
 // read default setting folders, render in folder select
 async function readDefaultFolders() {
   const folderSelect = $('#folder-select')
@@ -228,6 +257,7 @@ async function overwrite(args) {
 }
 
 module.exports = {
+  findProfiles,
   getSelectedProfile,
   readDefaultFolders,
   setSelectedFolder,

--- a/src/js/eve-folder.js
+++ b/src/js/eve-folder.js
@@ -5,6 +5,7 @@ const { shell, ipcRenderer } = require('electron')
 const { join } = require('path')
 const { statSync, existsSync } = require('fs')
 const { readdir, readFile, writeFile } = require('node:fs/promises')
+const { appendSelectOption, setSelectLoading, setSelectOptions } = require('./select-options')
 const { getLocale } = require('./change-language')
 const AppConfig = require('../configuration')
 const phin = require('phin')
@@ -46,7 +47,7 @@ const settingFolderName = 'settings_Default'
 // read default setting folders, render in folder select
 async function readDefaultFolders() {
   const folderSelect = $('#folder-select')
-  folderSelect.find('option').remove()
+  setSelectOptions(folderSelect, [])
 
   const server = $('#server-select').val() ?? 'tranquility'
   const os = process.platform
@@ -61,21 +62,13 @@ async function readDefaultFolders() {
   if (defaultDirs.length == 0) return
   
   // render default dirs
-  for (const dir of defaultDirs) {
-    folderSelect.append($('<option>', {
-      value: dir,
-      text: dir
-    }))
-  }
+  setSelectOptions(folderSelect, defaultDirs.map(dir => ({ value: dir, text: dir })))
   // load saved folder
   let savedFolder = AppConfig.readSettings(`savedFolder.${server}`)
   if (!savedFolder) {
     savedFolder = defaultDirs[0]
   } else if (!defaultDirs.includes(savedFolder)) {
-    folderSelect.append($('<option>', {
-      value: savedFolder,
-      text: savedFolder,
-    }))
+    appendSelectOption(folderSelect, savedFolder, savedFolder)
   }
   folderSelect.find('option[value="' + savedFolder + '"]').prop("selected", true)
 }
@@ -86,11 +79,7 @@ async function setSelectedFolder(folderPath) {
   const server = $('#server-select').val()
   AppConfig.saveSettings(`savedFolder.${server}`, folderPath)
   const folderSelect = $('#folder-select')
-  folderSelect.append($('<option>', {
-    value: folderPath,
-    text: folderPath,
-    selected: true
-  }))
+  appendSelectOption(folderSelect, folderPath, folderPath, true)
   // wait 0.1s to read the correct folder
   await new Promise(r => setTimeout(r, 100));
   readSettingFiles()
@@ -107,20 +96,19 @@ function openFolder() {
 async function readSettingFiles() {
   // get both char and user selects
   const selects = $('.select-list')
-  selects.find('option').remove()
 
   // set loading text
-  selects.append($('<option>', { val: 0, text: 'loading...' }))
+  setSelectLoading(selects)
 
   // read files
   const selectedFolder = $('#folder-select').val()
   if (!selectedFolder) {
-    selects.find('option').remove()
+    setSelectOptions(selects, [])
     return
   }
   const folderPath = join(selectedFolder, settingFolderName)
   if (!existsSync(folderPath)) {
-    selects.find('option').remove()
+    setSelectOptions(selects, [])
     return
   }
 
@@ -136,7 +124,7 @@ async function readSettingFiles() {
     .map(dirent => dirent.name.split('.')[0])
 
   if (files.length == 0) {
-    selects.find('option').remove()
+    setSelectOptions(selects, [])
     return
   }
 
@@ -199,24 +187,18 @@ async function readSettingFiles() {
   
   // render selects
   const charSelect = $('#char-select')
-  charSelect.find('option').remove()
-  for (const [filename, values] of Object.entries(chars)) {
-    const opt_text = `${values.id} - ${values.name} - ${values.mtime}` + (values.description ? ` - [${values.description}]` : '')
-    charSelect.append($('<option>', {
-      value: filename,
-      text: opt_text
-    }))
-  }
+  const characterToOption = ([filename, values]) => ({
+    value: filename,
+    text: `${values.id} - ${values.name} - ${values.mtime}` + (values.description ? ` - [${values.description}]` : '')
+  })
+  setSelectOptions(charSelect, Object.entries(chars).map(characterToOption))
 
   const userSelect = $('#user-select')
-  userSelect.find('option').remove()
-  for (const [filename, values] of Object.entries(users)) {
-    const opt_text = `${values.id} - ${values.mtime}` + (values.description ? ` - [${values.description}]` : '')
-    userSelect.append($('<option>', {
-      value: filename,
-      text: opt_text
-    }))
-  }
+  const userToOption = ([filename, values]) => ({
+    value: filename,
+    text: `${values.id} - ${values.mtime}` + (values.description ? ` - [${values.description}]` : '')
+  })
+  setSelectOptions(userSelect, Object.entries(users).map(userToOption))
 }
 
 // @params

--- a/src/js/eve-server.js
+++ b/src/js/eve-server.js
@@ -3,8 +3,9 @@
 const phin = require('phin')
 const $ = require('jquery')
 const AppConfig = require('../configuration')
+const { setSelectOptions } = require('./select-options')
 const { getLocale } = require('./change-language')
-const { readDefaultFolders, readSettingFiles } = require('./eve-folder.js')
+const { findProfiles } = require('./eve-folder.js')
 
 const urls = {
   "status": {
@@ -24,8 +25,9 @@ async function changeServer(server) {
   $('#server-title').text(title)
 
   // await getServerStatus()
-  await readDefaultFolders()
-  await readSettingFiles()
+  setSelectOptions($('#user-select'), [])
+  setSelectOptions($('#char-select'), [])
+  await findProfiles()
 }
 
 // update server status and player count

--- a/src/js/select-options.js
+++ b/src/js/select-options.js
@@ -1,0 +1,22 @@
+const $ = require('jquery')
+
+function setSelectLoading(select) {
+    setSelectOptions(select, [{ value: 0, text: 'loading…' }])
+}
+
+function appendSelectOption(select, value, text, selected) {
+    select.append($('<option>', { value, text, selected }))
+}
+
+function setSelectOptions(select, options) {
+    select.find('option').remove()
+    for (const option of options) {
+        appendSelectOption(select, option.value, option.text, option.selected)
+    }
+}
+
+module.exports = {
+    setSelectLoading,
+    appendSelectOption,
+    setSelectOptions
+}

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -5,7 +5,7 @@ const $ = require('jquery')
 const AppConfig = require('../configuration')
 const { changeLanguage } = require('./change-language')
 const { changeServer } = require('./eve-server')
-const { openFolder, setSelectedFolder, readSettingFiles, overwrite, readDefaultFolders } = require('./eve-folder')
+const { openFolder, getSelectedProfile, setSelectedFolder, readSettingFiles, overwrite, readDefaultFolders } = require('./eve-folder')
 const { editDescription } = require('./edit-description')
 const { backupFiles } = require('./backup')
 const { join } = require('path')
@@ -124,7 +124,8 @@ function bindEvents() {
     const select = $(`#${args.type}-select`).val()
     if (!select) return
     const folder = $('#folder-select').val()
-    args.folder = join(folder, 'settings_Default')
+    const profile = getSelectedProfile()
+    args.folder = join(folder, profile)
     args.selected = select + '.dat'
 
     let targets = $(`#${args.type}-select option`).not(':selected').toArray()

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -10,6 +10,7 @@ const { editDescription } = require('./edit-description')
 const { backupFiles } = require('./backup')
 const { join } = require('path')
 const { readdir } = require('node:fs/promises')
+const { setSelectOptions } = require('./select-options')
 
 const localePath = join(__dirname, '../locales')
 
@@ -33,15 +34,7 @@ async function initSelects() {
   const locales = (await readdir(localePath, { withFileTypes: true }))
     .filter(dirent => dirent.isFile() && dirent.name.endsWith('.json'))
     .map(dirent => join(localePath, dirent.name))
-  languageSelect.find('option').remove()
-  for (const locale of locales) {
-    const localeFile = require(locale)
-    const langValue = locale.replace(/^.*[\\\/]/, '').split('.')[0]
-    languageSelect.append($('<option>', {
-      value: langValue,
-      text: localeFile.language
-    }))
-  }
+  setSelectOptions(languageSelect, locales.map(locale => ({ value: locale.replace(/^.*[\\\/]/, '').split('.')[0], text: require(locale).language })))
 
   // set language
   let language = AppConfig.readSettings('language')

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -17,6 +17,7 @@ const localePath = join(__dirname, '../locales')
 const languageSelect = $('#language-select')
 const serverSelect = $('#server-select')
 const folderSelect = $('#folder-select')
+const profileSelect = $('#profile-select')
 const selectFolderBtn = $('#select-folder-btn')
 const openFolderBtn = $('#open-folder-btn')
 const backupBtn = $('#backup-btn')
@@ -69,6 +70,8 @@ function bindEvents() {
     AppConfig.saveSettings(`savedFolder.${serverSelect.val()}`, folderSelect.val())
     readSettingFiles()
   })
+
+  profileSelect.on('change', readSettingFiles)
 
   selectFolderBtn.on('click', async (e) => {
     e.preventDefault()

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -63,25 +63,34 @@
         </div>
       </div>
       <div id="select-titles" class="row">
-        <div class="col-7">
+        <div class="col-2">
+          <h4 id="profile-table-title">Profiles</h4>
+        </div>
+        <div class="col-6">
           <h4 id="char-table-title">Characters</h4>
         </div>
-        <div class="col-5">
+        <div class="col-4">
           <h4 id="account-table-title">Accounts</h4>
         </div>
       </div>
       <div id="table-section" class="row">
-        <div class="col-7">
+        <div class="col-2">
+          <select id="profile-select" class="form-select" size="18">
+          </select>
+        </div>
+        <div class="col-6">
           <select id="char-select" class="form-select select-list" size="18">
           </select>
         </div>
-        <div class="col-5">
+        <div class="col-4">
           <select id="user-select" class="form-select select-list" size="18">
           </select>
         </div>
       </div>
       <div id="select-buttons" class="row">
-        <div class="col-7">
+        <div class="col-2">
+        </div>
+        <div class="col-6">
           <div id="char-table-btn-group">
             <button id="edit-char-description-btn" type="button" class="edit-description-btn btn btn-outline-dark">
               <img src="../assets/edit-note.svg"/>
@@ -97,7 +106,7 @@
             </button>
           </div>
         </div>
-        <div class="col-5">
+        <div class="col-4">
           <div id="account-table-btn-group d-flex justify-content-evenly">
             <button id="edit-account-description-btn" type="button" class="edit-description-btn btn btn-outline-dark">
               <img src="../assets/edit-note.svg"/>

--- a/src/views/select.html
+++ b/src/views/select.html
@@ -34,6 +34,7 @@
   const $ = require('jquery')
   const { ipcRenderer, remote } = require('electron')
   const { getLocale } = require('../js/change-language')
+  const { setSelectOptions } = require('../js/select-options')
 
   const prefixes = {
     "user": "core_user_",
@@ -53,13 +54,7 @@
   // render the other options as candidates
   ipcRenderer.on('loadSelect', (event, args) => {
     localArgs = args
-    const options = args.targets
-    for (const option of options) {
-      select.append($('<option>', {
-        value: option.split(' - ')[0],
-        text: option
-      }))
-    }
+    setSelectOptions(select, args.targets.map(option => ({ value: option.split(' - ')[0], text: option })))
   })
 
   // confirm overwrite


### PR DESCRIPTION
This adds the ability to use the new launcher’s profiles. A new column has been added to the left of the character column, listing the profiles that have been located in the select settings folder.

Two refactorings were performed before the actual changes:
* All handling of select lists (showing “loading,” and setting/appending options to the lists) has been moved into its own file, removing a bit of duplicated code.
* The hardcoded profile name “settings_Default” was replaced by a function that would return the currently selected profile, or “settings_Default” if no profile was selected.

The actual changes are mostly unsurprising; upon changing the server or the settings folder, the list of profiles is parsed from the settings directory, clearing character and account lists until a profile has been selected. From there on out, everything works as it has before: files are overwritten only in the selected profile, and backups are created in the selected profile directories.

A word of warning, though: this has not been tested under Windows, and it has not been tested on a system that does not have the new launcher.

This addresses https://github.com/mintnick/eve-settings-manager/issues/1.