### PR TITLE
Clear character and account lists whenever the server or the settings folder is changed

### DIFF
--- a/src/js/eve-folder.js
+++ b/src/js/eve-folder.js
@@ -51,9 +51,8 @@ const defaultSettingFolderName = 'settings_Default'
  * @returns {Promise<void>}
  */
 async function findProfiles() {
-  await readDefaultFolders()
-
   // clear table
+  clearCharacterAndUserList()
   const profileSelect = $('#profile-select')
   setSelectLoading(profileSelect)
 
@@ -111,7 +110,13 @@ async function setSelectedFolder(folderPath) {
   appendSelectOption(folderSelect, folderPath, folderPath, true)
   // wait 0.1s to read the correct folder
   await new Promise(r => setTimeout(r, 100));
-  readSettingFiles()
+  await findProfiles()
+  await readSettingFiles()
+}
+
+function clearCharacterAndUserList() {
+  setSelectOptions($('#user-select'), [])
+  setSelectOptions($('#char-select'), [])
 }
 
 function getSelectedProfile() {

--- a/src/js/eve-server.js
+++ b/src/js/eve-server.js
@@ -6,6 +6,7 @@ const AppConfig = require('../configuration')
 const { setSelectOptions } = require('./select-options')
 const { getLocale } = require('./change-language')
 const { findProfiles } = require('./eve-folder.js')
+const { readDefaultFolders } = require('./eve-folder')
 
 const urls = {
   "status": {
@@ -25,8 +26,7 @@ async function changeServer(server) {
   $('#server-title').text(title)
 
   // await getServerStatus()
-  setSelectOptions($('#user-select'), [])
-  setSelectOptions($('#char-select'), [])
+  await readDefaultFolders()
   await findProfiles()
 }
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -5,7 +5,7 @@ const $ = require('jquery')
 const AppConfig = require('../configuration')
 const { changeLanguage } = require('./change-language')
 const { changeServer } = require('./eve-server')
-const { openFolder, getSelectedProfile, setSelectedFolder, readSettingFiles, overwrite, readDefaultFolders } = require('./eve-folder')
+const { openFolder, getSelectedProfile, setSelectedFolder, readSettingFiles, overwrite, findProfiles } = require('./eve-folder')
 const { editDescription } = require('./edit-description')
 const { backupFiles } = require('./backup')
 const { join } = require('path')
@@ -68,7 +68,7 @@ function bindEvents() {
 
   folderSelect.on('change', () => {
     AppConfig.saveSettings(`savedFolder.${serverSelect.val()}`, folderSelect.val())
-    readSettingFiles()
+    findProfiles()
   })
 
   profileSelect.on('change', readSettingFiles)


### PR DESCRIPTION
This adds reliable clearing of the character and account lists when switching servers, or settings folders.

I already had this locally in the other branch but forgot to push it before you merged it. 🤦 😁 